### PR TITLE
Fix for symmetrical option causing sim error

### DIFF
--- a/commands/sim.js
+++ b/commands/sim.js
@@ -34,7 +34,7 @@ module.exports = function container (get, set, clear) {
       .option('--profit_stop_pct <pct>', 'maintain a trailing stop this % below the high-water mark of profit', Number, c.profit_stop_pct)
       .option('--max_sell_loss_pct <pct>', 'avoid selling at a loss pct under this float', c.max_sell_loss_pct)
       .option('--max_slippage_pct <pct>', 'avoid selling at a slippage pct above this float', c.max_slippage_pct)
-      .option('--symmetrical', 'reverse time at the end of the graph, normalizing buy/hold to 0', Boolean, c.symmetrical)
+      .option('--symmetrical', 'reverse time at the end of the graph, normalizing buy/hold to 0', c.symmetrical)
       .option('--rsi_periods <periods>', 'number of periods to calculate RSI at', Number, c.rsi_periods)
       .option('--disable_options', 'disable printing of options')
       .option('--enable_stats', 'enable printing order stats')


### PR DESCRIPTION
By specifying `Boolean` in the declaration of the option, it caused an error by defaulting to `false`. If you tried to set it to `true` using `--symmetrical=true`, this would result in an error seen on issue #750. At this time there is still a bug with the symmetric code working.